### PR TITLE
Replace buffer usage for browser runtime compatibility

### DIFF
--- a/src/hooks/token/use-token.ts
+++ b/src/hooks/token/use-token.ts
@@ -6,14 +6,12 @@ import { AuthQueryContext } from "../../lib/auth-query-provider"
 import type { AuthClient } from "../../types/auth-client"
 import { useSession } from "../session/use-session"
 
-const decodeJwt = (token: string) => {
-    const parts = token
-        .split(".")
-        .map((part) => Buffer.from(part.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString())
+export const decodeJwt = (token: string) => {
+    const parts = token.split('.').map((part) =>
+        atob(part.replace(/-/g, '+').replace(/_/g, '/'))
+    )
 
-    const payload = JSON.parse(parts[1])
-
-    return payload
+    return JSON.parse(parts[1]);
 }
 
 export function useToken<TAuthClient extends AuthClient>(

--- a/src/hooks/token/use-token.ts
+++ b/src/hooks/token/use-token.ts
@@ -7,11 +7,17 @@ import type { AuthClient } from "../../types/auth-client"
 import { useSession } from "../session/use-session"
 
 export const decodeJwt = (token: string) => {
-    const parts = token.split('.').map((part) =>
-        atob(part.replace(/-/g, '+').replace(/_/g, '/'))
-    )
+    const decode = (data: string) => {
+        if (typeof Buffer === 'undefined') {
+            return atob(data)
+        }
+        return Buffer.from(data, 'base64').toString()
+    };
+    const parts = token
+        .split('.')
+        .map((part) => decode(part.replace(/-/g, '+').replace(/_/g, '/')))
 
-    return JSON.parse(parts[1]);
+    return JSON.parse(parts[1])
 }
 
 export function useToken<TAuthClient extends AuthClient>(


### PR DESCRIPTION
The current implementation uses Buffer which isn't always available needing node polyfills to work with vite.

I refactored it to use atob so no polyfills are needed.