### PR TITLE
A Refactor of 

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ export function useUpdateUser(
     options?: Partial<AuthQueryOptions>
 ) {
     type SessionData = typeof authClient["$Infer"]["Session"]
-    const { sessionKey: queryKey } = useContext(AuthQueryContext)
+    const { sessionKey: queryKey } = useAuthQueryContext()
 
     return useAuthMutation({
         queryKey,

--- a/src/hooks/accounts/use-list-accounts.ts
+++ b/src/hooks/accounts/use-list-accounts.ts
@@ -1,7 +1,6 @@
 import type { AnyUseQueryOptions } from "@tanstack/react-query"
-import { useContext } from "react"
 
-import { AuthQueryContext } from "../../lib/auth-query-provider"
+import { useAuthQueryContext } from "../../lib/auth-query-provider"
 import type { AnyAuthClient } from "../../types/any-auth-client"
 import { useAuthQuery } from "../shared/use-auth-query"
 
@@ -9,7 +8,7 @@ export function useListAccounts<TAuthClient extends AnyAuthClient>(
     authClient: TAuthClient,
     options?: Partial<AnyUseQueryOptions>
 ) {
-    const { listAccountsKey: queryKey } = useContext(AuthQueryContext)
+    const { listAccountsKey: queryKey } = useAuthQueryContext()
 
     return useAuthQuery({
         authClient,

--- a/src/hooks/accounts/use-unlink-account.ts
+++ b/src/hooks/accounts/use-unlink-account.ts
@@ -1,5 +1,4 @@
-import { useContext } from "react"
-import { AuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
+import { useAuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
 import type { AnyAuthClient } from "../../types/any-auth-client"
 import { useAuthMutation } from "../shared/use-auth-mutation"
 
@@ -7,7 +6,7 @@ export function useUnlinkAccount<TAuthClient extends AnyAuthClient>(
     authClient: TAuthClient,
     options?: AuthQueryOptions
 ) {
-    const { listAccountsKey: queryKey } = useContext(AuthQueryContext)
+    const { listAccountsKey: queryKey } = useAuthQueryContext()
 
     return useAuthMutation({
         queryKey,

--- a/src/hooks/api-key/use-create-api-key.ts
+++ b/src/hooks/api-key/use-create-api-key.ts
@@ -1,5 +1,4 @@
-import { useContext } from "react"
-import { AuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
+import { useAuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
 import type { AuthClient } from "../../types/auth-client"
 import { useAuthMutation } from "../shared/use-auth-mutation"
 
@@ -7,7 +6,7 @@ export function useCreateApiKey<TAuthClient extends AuthClient>(
     authClient: TAuthClient,
     options?: Partial<AuthQueryOptions>
 ) {
-    const { listApiKeysKey: queryKey } = useContext(AuthQueryContext)
+    const { listApiKeysKey: queryKey } = useAuthQueryContext()
 
     return useAuthMutation({
         queryKey,

--- a/src/hooks/api-key/use-delete-api-key.ts
+++ b/src/hooks/api-key/use-delete-api-key.ts
@@ -1,5 +1,4 @@
-import { useContext } from "react"
-import { AuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
+import { useAuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
 import type { AuthClient } from "../../types/auth-client"
 import { useAuthMutation } from "../shared/use-auth-mutation"
 
@@ -7,7 +6,7 @@ export function useDeleteApiKey<TAuthClient extends AuthClient>(
     authClient: TAuthClient,
     options?: Partial<AuthQueryOptions>
 ) {
-    const { listApiKeysKey: queryKey } = useContext(AuthQueryContext)
+    const { listApiKeysKey: queryKey } = useAuthQueryContext()
 
     return useAuthMutation({
         queryKey,

--- a/src/hooks/api-key/use-list-api-keys.ts
+++ b/src/hooks/api-key/use-list-api-keys.ts
@@ -1,7 +1,6 @@
 import type { AnyUseQueryOptions } from "@tanstack/react-query"
-import { useContext } from "react"
 
-import { AuthQueryContext } from "../../lib/auth-query-provider"
+import { useAuthQueryContext } from "../../lib/auth-query-provider"
 
 import type { AuthClient } from "../../types/auth-client"
 import { useAuthQuery } from "../shared/use-auth-query"
@@ -10,7 +9,7 @@ export function useListApiKeys<TAuthClient extends AuthClient>(
     authClient: TAuthClient,
     options?: Partial<AnyUseQueryOptions>
 ) {
-    const { listApiKeysKey: queryKey } = useContext(AuthQueryContext)
+    const { listApiKeysKey: queryKey } = useAuthQueryContext()
 
     return useAuthQuery({
         authClient,

--- a/src/hooks/device-sessions/use-list-device-sessions.ts
+++ b/src/hooks/device-sessions/use-list-device-sessions.ts
@@ -1,7 +1,6 @@
 import type { AnyUseQueryOptions } from "@tanstack/react-query"
-import { useContext } from "react"
 
-import { AuthQueryContext } from "../../lib/auth-query-provider"
+import { useAuthQueryContext } from "../../lib/auth-query-provider"
 
 import type { AuthClient } from "../../types/auth-client"
 import { useAuthQuery } from "../shared/use-auth-query"
@@ -10,7 +9,7 @@ export function useListDeviceSessions<TAuthClient extends AuthClient>(
     authClient: TAuthClient,
     options?: Partial<AnyUseQueryOptions>
 ) {
-    const { listDeviceSessionsKey: queryKey } = useContext(AuthQueryContext)
+    const { listDeviceSessionsKey: queryKey } = useAuthQueryContext()
 
     return useAuthQuery({
         authClient,

--- a/src/hooks/device-sessions/use-revoke-device-session.ts
+++ b/src/hooks/device-sessions/use-revoke-device-session.ts
@@ -1,5 +1,4 @@
-import { useContext } from "react"
-import { AuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
+import { useAuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
 import type { AuthClient } from "../../types/auth-client"
 import { useAuthMutation } from "../shared/use-auth-mutation"
 
@@ -7,7 +6,7 @@ export function useRevokeDeviceSession<TAuthClient extends AuthClient>(
     authClient: TAuthClient,
     options?: Partial<AuthQueryOptions>
 ) {
-    const { listDeviceSessionsKey: queryKey } = useContext(AuthQueryContext)
+    const { listDeviceSessionsKey: queryKey } = useAuthQueryContext()
 
     return useAuthMutation({
         queryKey,

--- a/src/hooks/device-sessions/use-revoke-device-sessions.ts
+++ b/src/hooks/device-sessions/use-revoke-device-sessions.ts
@@ -1,5 +1,4 @@
-import { useContext } from "react"
-import { AuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
+import { useAuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
 import type { AuthClient } from "../../types/auth-client"
 import { useAuthMutation } from "../shared/use-auth-mutation"
 
@@ -7,7 +6,7 @@ export function useRevokeDeviceSessions<TAuthClient extends AuthClient>(
     authClient: TAuthClient,
     options?: AuthQueryOptions
 ) {
-    const { listDeviceSessionsKey: queryKey } = useContext(AuthQueryContext)
+    const { listDeviceSessionsKey: queryKey } = useAuthQueryContext()
 
     return useAuthMutation({
         queryKey,

--- a/src/hooks/device-sessions/use-set-active-session.ts
+++ b/src/hooks/device-sessions/use-set-active-session.ts
@@ -1,8 +1,7 @@
 import { useMutation } from "@tanstack/react-query"
 import { useQueryClient } from "@tanstack/react-query"
-import { useContext } from "react"
 
-import { AuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
+import { useAuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
 
 import type { AuthClient } from "../../types/auth-client"
 import { useOnMutateError } from "../shared/use-mutate-error"
@@ -15,7 +14,7 @@ export function useSetActiveSession<TAuthClient extends AuthClient>(
 
     const queryClient = useQueryClient()
     const { onMutateError } = useOnMutateError()
-    const context = useContext(AuthQueryContext)
+    const context = useAuthQueryContext()
     const { listDeviceSessionsKey: queryKey } = { ...context, ...options }
 
     const mutation = useMutation({

--- a/src/hooks/passkey/use-delete-passkey.ts
+++ b/src/hooks/passkey/use-delete-passkey.ts
@@ -1,5 +1,4 @@
-import { useContext } from "react"
-import { AuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
+import { useAuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
 import type { AuthClient } from "../../types/auth-client"
 import { useAuthMutation } from "../shared/use-auth-mutation"
 
@@ -7,7 +6,7 @@ export function useDeletePasskey<TAuthClient extends AuthClient>(
     authClient: TAuthClient,
     options?: Partial<AuthQueryOptions>
 ) {
-    const { listPasskeysKey: queryKey } = useContext(AuthQueryContext)
+    const { listPasskeysKey: queryKey } = useAuthQueryContext()
 
     return useAuthMutation({
         queryKey,

--- a/src/hooks/passkey/use-list-passkeys.ts
+++ b/src/hooks/passkey/use-list-passkeys.ts
@@ -1,7 +1,6 @@
 import type { AnyUseQueryOptions } from "@tanstack/react-query"
-import { useContext } from "react"
 
-import { AuthQueryContext } from "../../lib/auth-query-provider"
+import { useAuthQueryContext } from "../../lib/auth-query-provider"
 import type { AuthClient } from "../../types/auth-client"
 import { useAuthQuery } from "../shared/use-auth-query"
 
@@ -9,7 +8,7 @@ export function useListPasskeys<TAuthClient extends AuthClient>(
     authClient: TAuthClient,
     options?: Partial<AnyUseQueryOptions>
 ) {
-    const { listPasskeysKey: queryKey } = useContext(AuthQueryContext)
+    const { listPasskeysKey: queryKey } = useAuthQueryContext()
 
     return useAuthQuery({
         authClient,

--- a/src/hooks/session/use-session.ts
+++ b/src/hooks/session/use-session.ts
@@ -1,7 +1,6 @@
 import { type AnyUseQueryOptions, useQuery } from "@tanstack/react-query"
-import { useContext } from "react"
 
-import { AuthQueryContext } from "../../lib/auth-query-provider"
+import { useAuthQueryContext } from "../../lib/auth-query-provider"
 import type { AnyAuthClient } from "../../types/any-auth-client"
 import type { AuthClient } from "../../types/auth-client"
 
@@ -13,7 +12,7 @@ export function useSession<TAuthClient extends AnyAuthClient>(
     type User = TAuthClient["$Infer"]["Session"]["user"]
     type Session = TAuthClient["$Infer"]["Session"]["session"]
 
-    const { sessionQueryOptions, sessionKey: queryKey, queryOptions } = useContext(AuthQueryContext)
+    const { sessionQueryOptions, sessionKey: queryKey, queryOptions } = useAuthQueryContext()
     const mergedOptions = { ...queryOptions, ...sessionQueryOptions, ...options }
 
     const result = useQuery<SessionData>({

--- a/src/hooks/session/use-update-user.ts
+++ b/src/hooks/session/use-update-user.ts
@@ -1,5 +1,4 @@
-import { useContext } from "react"
-import { AuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
+import { useAuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
 import type { AnyAuthClient } from "../../types/any-auth-client"
 import { useAuthMutation } from "../shared/use-auth-mutation"
 
@@ -9,7 +8,7 @@ export function useUpdateUser<TAuthClient extends AnyAuthClient>(
 ) {
     type SessionData = TAuthClient["$Infer"]["Session"]
 
-    const { sessionKey: queryKey } = useContext(AuthQueryContext)
+    const { sessionKey: queryKey } = useAuthQueryContext()
 
     return useAuthMutation({
         queryKey,

--- a/src/hooks/sessions/use-list-sessions.ts
+++ b/src/hooks/sessions/use-list-sessions.ts
@@ -1,7 +1,6 @@
 import type { AnyUseQueryOptions } from "@tanstack/react-query"
-import { useContext } from "react"
 
-import { AuthQueryContext } from "../../lib/auth-query-provider"
+import { useAuthQueryContext } from "../../lib/auth-query-provider"
 import type { AnyAuthClient } from "../../types/any-auth-client"
 import { useAuthQuery } from "../shared/use-auth-query"
 
@@ -9,6 +8,6 @@ export function useListSessions<TAuthClient extends AnyAuthClient>(
     authClient: TAuthClient,
     options?: Partial<AnyUseQueryOptions>
 ) {
-    const { listSessionsKey: queryKey } = useContext(AuthQueryContext)
+    const { listSessionsKey: queryKey } = useAuthQueryContext()
     return useAuthQuery({ authClient, queryKey, queryFn: authClient.listSessions, options })
 }

--- a/src/hooks/sessions/use-revoke-other-sessions.ts
+++ b/src/hooks/sessions/use-revoke-other-sessions.ts
@@ -1,5 +1,4 @@
-import { useContext } from "react"
-import { AuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
+import { useAuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
 import type { AnyAuthClient } from "../../types/any-auth-client"
 import { useSession } from "../session/use-session"
 import { useAuthMutation } from "../shared/use-auth-mutation"
@@ -10,7 +9,7 @@ export function useRevokeOtherSessions<TAuthClient extends AnyAuthClient>(
 ) {
     type Session = TAuthClient["$Infer"]["Session"]["session"]
 
-    const { listSessionsKey: queryKey } = useContext(AuthQueryContext)
+    const { listSessionsKey: queryKey } = useAuthQueryContext()
     const { data: sessionData } = useSession(authClient)
 
     return useAuthMutation({

--- a/src/hooks/sessions/use-revoke-session.ts
+++ b/src/hooks/sessions/use-revoke-session.ts
@@ -1,5 +1,4 @@
-import { useContext } from "react"
-import { AuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
+import { useAuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
 import type { AnyAuthClient } from "../../types/any-auth-client"
 import { useAuthMutation } from "../shared/use-auth-mutation"
 
@@ -7,8 +6,7 @@ export function useRevokeSession<TAuthClient extends AnyAuthClient>(
     authClient: TAuthClient,
     options?: Partial<AuthQueryOptions>
 ) {
-    type Session = TAuthClient["$Infer"]["Session"]["session"]
-    const { listSessionsKey: queryKey } = useContext(AuthQueryContext)
+    const { listSessionsKey: queryKey } = useAuthQueryContext()
 
     return useAuthMutation({
         queryKey,

--- a/src/hooks/sessions/use-revoke-sessions.ts
+++ b/src/hooks/sessions/use-revoke-sessions.ts
@@ -1,5 +1,4 @@
-import { useContext } from "react"
-import { AuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
+import { useAuthQueryContext, type AuthQueryOptions } from "../../lib/auth-query-provider"
 import type { AnyAuthClient } from "../../types/any-auth-client"
 import { useAuthMutation } from "../shared/use-auth-mutation"
 
@@ -7,7 +6,7 @@ export function useRevokeSessions<TAuthClient extends AnyAuthClient>(
     authClient: TAuthClient,
     options?: Partial<AuthQueryOptions>
 ) {
-    const { listSessionsKey: queryKey } = useContext(AuthQueryContext)
+    const { listSessionsKey: queryKey } = useAuthQueryContext()
 
     return useAuthMutation({
         queryKey,

--- a/src/hooks/shared/use-auth-mutation.ts
+++ b/src/hooks/shared/use-auth-mutation.ts
@@ -1,8 +1,7 @@
 import { type QueryKey, useMutation, useQueryClient } from "@tanstack/react-query"
 import type { BetterFetchOption } from "better-auth/react"
-import { useContext } from "react"
 import type { AuthQueryOptions, NonThrowableResult, ThrowableResult } from "../.."
-import { AuthQueryContext } from "../../lib/auth-query-provider"
+import { useAuthQueryContext } from "../../lib/auth-query-provider"
 import { useOnMutateError } from "./use-mutate-error"
 
 type AuthMutationFn<TParams> = (params: TParams) => Promise<ThrowableResult | NonThrowableResult>
@@ -26,7 +25,7 @@ export function useAuthMutation<
 }) {
     type TParams = Parameters<TAuthFn>[0]
     const queryClient = useQueryClient()
-    const context = useContext(AuthQueryContext)
+    const context = useAuthQueryContext()
     const { optimistic } = { ...context, ...options }
     const { onMutateError } = useOnMutateError()
 

--- a/src/hooks/shared/use-auth-query.ts
+++ b/src/hooks/shared/use-auth-query.ts
@@ -1,9 +1,8 @@
 import { type QueryKey, skipToken } from "@tanstack/query-core"
 import { type AnyUseQueryOptions, useQuery } from "@tanstack/react-query"
 import type { BetterFetchOption, BetterFetchResponse } from "better-auth/react"
-import { useContext } from "react"
 
-import { AuthQueryContext } from "../../lib/auth-query-provider"
+import { useAuthQueryContext } from "../../lib/auth-query-provider"
 import type { AnyAuthClient } from "../../types/any-auth-client"
 import { useSession } from "../session/use-session"
 
@@ -25,7 +24,7 @@ export function useAuthQuery<TData, TAuthClient extends AnyAuthClient = AnyAuthC
     options
 }: UseAuthQueryProps<TData, TAuthClient>) {
     const { data: sessionData } = useSession(authClient)
-    const { queryOptions } = useContext(AuthQueryContext)
+    const { queryOptions } = useAuthQueryContext()
     const mergedOptions = { ...queryOptions, ...options }
 
     return useQuery<TData>({

--- a/src/hooks/shared/use-mutate-error.ts
+++ b/src/hooks/shared/use-mutate-error.ts
@@ -1,10 +1,9 @@
 import { type Query, type QueryKey, useQueryClient } from "@tanstack/react-query"
-import { useContext } from "react"
-import { AuthQueryContext } from "../../lib/auth-query-provider"
+import { useAuthQueryContext } from "../../lib/auth-query-provider"
 
 export const useOnMutateError = () => {
     const queryClient = useQueryClient()
-    const { optimistic } = useContext(AuthQueryContext)
+    const { optimistic } = useAuthQueryContext()
 
     const onMutateError = (
         error: Error,

--- a/src/hooks/token/use-token.ts
+++ b/src/hooks/token/use-token.ts
@@ -1,7 +1,7 @@
 import type { AnyUseQueryOptions } from "@tanstack/react-query"
-import { useCallback, useContext, useEffect, useMemo } from "react"
+import { useCallback, useEffect, useMemo } from "react"
 
-import { AuthQueryContext } from "../../lib/auth-query-provider"
+import { useAuthQueryContext } from "../../lib/auth-query-provider"
 
 import type { AnyAuthClient } from "../../types/any-auth-client"
 import { useSession } from "../session/use-session"
@@ -25,7 +25,7 @@ export function useToken<TAuthClient extends AnyAuthClient>(
     options?: Partial<AnyUseQueryOptions>
 ) {
     const { data: sessionData } = useSession(authClient, options)
-    const { tokenKey, tokenQueryOptions, queryOptions } = useContext(AuthQueryContext)
+    const { tokenKey, tokenQueryOptions, queryOptions } = useAuthQueryContext()
     const mergedOptions = { ...queryOptions, ...tokenQueryOptions, ...options }
 
     const queryResult = useAuthQuery<{ token: string }>({

--- a/src/lib/auth-query-provider.tsx
+++ b/src/lib/auth-query-provider.tsx
@@ -1,61 +1,69 @@
 "use client"
 
 import type { AnyUseQueryOptions, QueryKey } from "@tanstack/react-query"
-import { type ReactNode, createContext } from "react"
+import { type ReactNode, createContext, useContext } from "react"
 
 export type AuthQueryOptions = {
-    queryOptions?: Partial<AnyUseQueryOptions>
-    sessionQueryOptions?: Partial<AnyUseQueryOptions>
-    tokenQueryOptions?: Partial<AnyUseQueryOptions>
-    sessionKey: QueryKey
-    tokenKey: QueryKey
-    listAccountsKey: QueryKey
-    listApiKeysKey: QueryKey
-    listSessionsKey: QueryKey
-    listDeviceSessionsKey: QueryKey
-    listPasskeysKey: QueryKey
-    optimistic: boolean
-    refetchOnMutate: boolean
+  queryOptions?: Partial<AnyUseQueryOptions>
+  sessionQueryOptions?: Partial<AnyUseQueryOptions>
+  tokenQueryOptions?: Partial<AnyUseQueryOptions>
+  sessionKey: QueryKey
+  tokenKey: QueryKey
+  listAccountsKey: QueryKey
+  listApiKeysKey: QueryKey
+  listSessionsKey: QueryKey
+  listDeviceSessionsKey: QueryKey
+  listPasskeysKey: QueryKey
+  optimistic: boolean
+  refetchOnMutate: boolean
 }
 
 export const defaultAuthQueryOptions: AuthQueryOptions = {
-    sessionKey: ["session"],
-    tokenKey: ["token"],
-    listAccountsKey: ["list-accounts"],
-    listApiKeysKey: ["list-api-keys"],
-    listSessionsKey: ["list-sessions"],
-    listDeviceSessionsKey: ["list-device-sessions"],
-    listPasskeysKey: ["list-passkeys"],
-    optimistic: true,
-    refetchOnMutate: true
+  sessionKey: ["session"],
+  tokenKey: ["token"],
+  listAccountsKey: ["list-accounts"],
+  listApiKeysKey: ["list-api-keys"],
+  listSessionsKey: ["list-sessions"],
+  listDeviceSessionsKey: ["list-device-sessions"],
+  listPasskeysKey: ["list-passkeys"],
+  optimistic: true,
+  refetchOnMutate: true
 }
 
 export const AuthQueryContext = createContext<AuthQueryOptions>(defaultAuthQueryOptions)
 
+export const useAuthQueryContext = () => {
+  const ctx = useContext(AuthQueryContext)
+  if (ctx === null || ctx === undefined) {
+    throw new Error('[Better Auth Tanstack] useAuthQueryContext must be used within a AuthQueryProvider.')
+  }
+  return ctx
+}
+
 export const AuthQueryProvider = ({
-    children,
-    sessionQueryOptions,
-    tokenQueryOptions,
-    ...props
+  children,
+  sessionQueryOptions,
+  tokenQueryOptions,
+  ...props
 }: {
-    children: ReactNode
+  children: ReactNode
 } & Partial<AuthQueryOptions>) => {
-    return (
-        <AuthQueryContext.Provider
-            value={{
-                sessionQueryOptions: {
-                    staleTime: 60 * 1000,
-                    ...sessionQueryOptions
-                },
-                tokenQueryOptions: {
-                    staleTime: 600 * 1000,
-                    ...tokenQueryOptions
-                },
-                ...defaultAuthQueryOptions,
-                ...props
-            }}
-        >
-            {children}
-        </AuthQueryContext.Provider>
-    )
+  return (
+    <AuthQueryContext.Provider
+      value={{
+        sessionQueryOptions: {
+          staleTime: 60 * 1000,
+          ...sessionQueryOptions
+        },
+        tokenQueryOptions: {
+          staleTime: 600 * 1000,
+          ...tokenQueryOptions
+        },
+        ...defaultAuthQueryOptions,
+        ...props
+      }}
+    >
+      {children}
+    </AuthQueryContext.Provider>
+  )
 }

--- a/src/lib/create-auth-hooks.ts
+++ b/src/lib/create-auth-hooks.ts
@@ -1,6 +1,5 @@
 import type { AnyUseQueryOptions, QueryKey } from "@tanstack/react-query"
 import { useQueryClient } from "@tanstack/react-query"
-import { useContext } from "react"
 
 import { useListAccounts } from "../hooks/accounts/use-list-accounts"
 import { useUnlinkAccount } from "../hooks/accounts/use-unlink-account"
@@ -27,7 +26,7 @@ import { type BetterFetchRequest, useAuthQuery } from "../hooks/shared/use-auth-
 import { useToken } from "../hooks/token/use-token"
 import type { AnyAuthClient } from "../types/any-auth-client"
 import type { AuthClient } from "../types/auth-client"
-import { AuthQueryContext, type AuthQueryOptions } from "./auth-query-provider"
+import { useAuthQueryContext, type AuthQueryOptions } from "./auth-query-provider"
 import { prefetchSession } from "./prefetch-session"
 
 export function createAuthHooks<TAuthClient extends AnyAuthClient>(authClient: TAuthClient) {
@@ -35,7 +34,7 @@ export function createAuthHooks<TAuthClient extends AnyAuthClient>(authClient: T
         useSession: (options?: Partial<AnyUseQueryOptions>) => useSession(authClient, options),
         usePrefetchSession: (options?: Partial<AnyUseQueryOptions>) => {
             const queryClient = useQueryClient()
-            const queryOptions = useContext(AuthQueryContext)
+            const queryOptions = useAuthQueryContext()
 
             return {
                 prefetch: () => prefetchSession(authClient, queryClient, queryOptions, options)


### PR DESCRIPTION
### Refactored 

1. `useContext(AuthQueryContext)` to `useAuthQueryContext()`
2. Added a Simple Check and Error log to make sure that before using the  `useAuthQueryContext()` its wrapped in the Provider